### PR TITLE
ポケモンシルエットクイズbot用にテーブルを用意する

### DIFF
--- a/db/migrate/20240229042807_create_users.rb
+++ b/db/migrate/20240229042807_create_users.rb
@@ -1,7 +1,7 @@
 class CreateUsers < ActiveRecord::Migration[6.0]
   def change
     create_table :users do |t|
-      t.string :user_id, null: false , unique: true
+      t.string :line_user_id, null: false , unique: true
 
       t.timestamps
     end

--- a/db/migrate/20240229042807_create_users.rb
+++ b/db/migrate/20240229042807_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users , id: false do |t|
+      t.column :user_id, 'INT PRIMARY KEY AUTO_INCREMENT', null: false
+      t.string :user_id, null: false , unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240229042807_create_users.rb
+++ b/db/migrate/20240229042807_create_users.rb
@@ -1,7 +1,6 @@
 class CreateUsers < ActiveRecord::Migration[6.0]
   def change
-    create_table :users , id: false do |t|
-      t.column :user_id, 'INT PRIMARY KEY AUTO_INCREMENT', null: false
+    create_table :users do |t|
       t.string :user_id, null: false , unique: true
 
       t.timestamps

--- a/db/migrate/20240229042844_create_quizzes.rb
+++ b/db/migrate/20240229042844_create_quizzes.rb
@@ -2,7 +2,7 @@ class CreateQuizzes < ActiveRecord::Migration[6.0]
   def change
     create_table :users , id: false do |t|
       t.column :quiz_id, 'INT PRIMARY KEY AUTO_INCREMENT', null: false
-      t.integer :user_id, null: false
+      t.references :user, foreign_key: true, null: false
       t.integer :pokemon_id , null: false
       t.integer :challenge_upper_limit , null: false
 

--- a/db/migrate/20240229042844_create_quizzes.rb
+++ b/db/migrate/20240229042844_create_quizzes.rb
@@ -1,7 +1,6 @@
 class CreateQuizzes < ActiveRecord::Migration[6.0]
   def change
-    create_table :users , id: false do |t|
-      t.column :quiz_id, 'INT PRIMARY KEY AUTO_INCREMENT', null: false
+    create_table :users do |t|
       t.references :user, foreign_key: true, null: false
       t.integer :pokemon_id , null: false
       t.integer :challenge_upper_limit , null: false

--- a/db/migrate/20240229042844_create_quizzes.rb
+++ b/db/migrate/20240229042844_create_quizzes.rb
@@ -1,0 +1,11 @@
+class CreateQuizzes < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users , id: false do |t|
+      t.column :quiz_id, 'INT PRIMARY KEY AUTO_INCREMENT', null: false
+      t.integer :user_id, null: false
+      t.integer :pokemon_id , null: false
+      t.integer :challenge_upper_limit , null: false
+
+      t.timestamps
+  end
+end

--- a/db/migrate/20240229042852_create_answers.rb
+++ b/db/migrate/20240229042852_create_answers.rb
@@ -1,7 +1,6 @@
 class CreateAnswers < ActiveRecord::Migration[6.0]
   def change
     create_table :answers do |t|
-      t.column :answer_id, 'INT PRIMARY KEY AUTO_INCREMENT', null: false
       t.references :quiz, foreign_key: true, null: false
       t.string :answer_text null: false
       t.boolean :answer_succeed, null: false

--- a/db/migrate/20240229042852_create_answers.rb
+++ b/db/migrate/20240229042852_create_answers.rb
@@ -1,0 +1,12 @@
+class CreateAnswers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :answers do |t|
+      t.column :answer_id, 'INT PRIMARY KEY AUTO_INCREMENT', null: false
+      t.integer :quiz_id, null: false
+      t.string :answer_text null: false
+      t.boolean :answer_succeed, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240229042852_create_answers.rb
+++ b/db/migrate/20240229042852_create_answers.rb
@@ -2,7 +2,7 @@ class CreateAnswers < ActiveRecord::Migration[6.0]
   def change
     create_table :answers do |t|
       t.column :answer_id, 'INT PRIMARY KEY AUTO_INCREMENT', null: false
-      t.integer :quiz_id, null: false
+      t.references :quiz, foreign_key: true, null: false
       t.string :answer_text null: false
       t.boolean :answer_succeed, null: false
 


### PR DESCRIPTION
## 実装の背景・目的
ポケモンシルエットクイズbot用にテーブルを用意する


## やったこと
下のテーブル設計に基づいてマイグレーションファイルに定義を行った。

## キャプチャ

![er____poke_quiz drawio__1__480](https://github.com/Ishigami100/intern-line-bot/assets/66787937/0728d8f7-66e4-4339-860a-ced182f95886)


## 補足

- [x] テーブルを作成する
- [x] テーブルの確認後に、リレーションを引く
