### PR TITLE
画像のURLを指定し、画像を流せるようにする

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -29,7 +29,7 @@ class WebhookController < ApplicationController
           user = User.find_or_create_by(line_user_id: line_user_id)
           #入力文字で条件分岐
           if event.message['text'] == "スタート"
-            quiz=Quiz.start_quiz(user.id)
+            quiz=Quiz.start_quiz(user)
             client.reply_message(event['replyToken'],quiz.image_message(request.base_url))
             client.push_message(line_user_id,quiz.question_message)
           else

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -29,9 +29,8 @@ class WebhookController < ApplicationController
           user = User.find_or_create_by(line_user_id: line_user_id)
           #入力文字で条件分岐
           if event.message['text'] == "スタート"
-            quiz=Quiz.start_quiz(line_user_id)
-            p request.base_url
-            client.reply_message(event['replyToken'],quiz.image_message)
+            quiz=Quiz.start_quiz(user.id)
+            client.reply_message(event['replyToken'],quiz.image_message(request.base_url))
             client.push_message(line_user_id,quiz.question_message)
           else
             user.current_quiz.answer(answer_text: event.message['text'])

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -5,8 +5,8 @@ class Quiz < ApplicationRecord
     belongs_to :user 
     has_many :answers
 
-    def self.start_quiz(user_id)
-        Quiz.create(user_id: user_id, pokemon_id: random_pokemon_id, challenge_upper_limit: CHALLENGE_UPPER_LIMIT)
+    def self.start_quiz(user)
+        Quiz.create(user_id: user.id, pokemon_id: random_pokemon_id, challenge_upper_limit: CHALLENGE_UPPER_LIMIT)
     end
 
     def answer(answer_text:)
@@ -26,7 +26,7 @@ class Quiz < ApplicationRecord
     end
 
     def image_message(base_url)
-        image_url = base_url+ActionController::Base.helpers.asset_url('gray/'+format("%03d", pokemon_id)+'.png')
+        image_url = "#{base_url}#{ActionController::Base.helpers.asset_url('gray/'+format("%03d", pokemon_id))}"
         image_message = {
             type: 'image',
             originalContentUrl: image_url,

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -5,8 +5,7 @@ class Quiz < ApplicationRecord
     belongs_to :user 
     has_many :answers
 
-    def self.start_quiz(line_user_id)
-        user_id = User.find_by!(line_user_id: line_user_id).id
+    def self.start_quiz(user_id)
         Quiz.create(user_id: user_id, pokemon_id: random_pokemon_id, challenge_upper_limit: CHALLENGE_UPPER_LIMIT)
     end
 
@@ -26,12 +25,12 @@ class Quiz < ApplicationRecord
         }
     end
 
-    def image_message
-        image_path = 'images/gray'+pokemon_id.to_s+'.png'
+    def image_message(base_url)
+        image_url = base_url+ActionController::Base.helpers.asset_url('gray/'+format("%03d", pokemon_id)+'.png')
         image_message = {
             type: 'image',
-            originalContentUrl: 
-            previewImageUrl: 
+            originalContentUrl: image_url,
+            previewImageUrl:  image_url
         }
     end
 


### PR DESCRIPTION
## 実装の背景・目的

今までの処理では、画像のURLがない状態であった。
それをcontrollerの方からベースとなるURLを取得し、quiz.rb側で加工して画像のURLとなるようにする。

## やったこと
controllerのimage_messageの引数を変更
quiz.rbのimage_messageに処理を追加する。

## 補足
今後の流れ
- [ ] Pokemon APIの処理を追加する
- [ ] ヒントを流せるようにする
- [ ] 例外処理を描く
