### PR TITLE
POKEMON APIを呼び出す部分を作成する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,3 +53,4 @@ gem 'psych', '< 4'
 gem 'net-smtp', require: false
 gem 'net-imap', require: false
 gem 'net-pop', require: false
+gem 'httpclient'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    httpclient (2.8.3)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
@@ -205,6 +206,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   coffee-rails
+  httpclient
   jbuilder
   jquery-rails
   line-bot-api

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -1,6 +1,11 @@
+require "httpclient"
 class Quiz < ApplicationRecord
     CHALLENGE_UPPER_LIMIT = 5
-    MAX_POKEMON_ID = 150
+    MAX_POKEMON_ID = 151
+    
+    BASE_URL = "https://pokeapi.co/api/v2"
+    POKEMON_SPECIES_URL = "/pokemon-species/"
+    POKEMON_URL = "/pokemon/"
 
     belongs_to :user 
     has_many :answers
@@ -58,7 +63,8 @@ class Quiz < ApplicationRecord
 
     def is_answer_succeed?(input_text)
         return false if validate_text?(input_text)
-        answer_text = "ピカチュウ" #仮
+        p pokemon_type(1)
+        answer_text = pokemon_name_jp(self.pokemon_id)
         if  input_text == answer_text
             true
         else
@@ -94,4 +100,75 @@ class Quiz < ApplicationRecord
         return true if text =~ /\A[ァ-ヶー－]+\z/
         false
     end 
+
+    def pokemon_name_jp(pokemon_id)
+        url = "#{BASE_URL}#{POKEMON_SPECIES_URL}#{pokemon_id.to_s}"
+        client = HTTPClient.new                 # インスタンスを生成
+        response = client.get(url)   
+        results=JSON.parse(response.body) 
+        results['names'].each do |name_info|
+            if name_info['language']['name'] == 'ja-Hrkt'
+                return name_info['name']
+            end
+        end
+        return "Not Found"
+    end
+
+    def pokemon_name_en(pokemon_id)
+        url = "#{BASE_URL}#{POKEMON_SPECIES_URL}#{pokemon_id.to_s}"
+        client = HTTPClient.new                 # インスタンスを生成
+        response = client.get(url)   
+        results=JSON.parse(response.body) 
+        results['names'].each do |name_info|
+            if name_info['language']['name'] == 'en'
+                return name_info['name']
+            end
+        end
+        return "Not Found"
+    end
+
+    def pokemon_name_ch(pokemon_id)
+        url = "#{BASE_URL}#{POKEMON_SPECIES_URL}#{pokemon_id.to_s}"
+        client = HTTPClient.new                 # インスタンスを生成
+        response = client.get(url)   
+        results=JSON.parse(response.body) 
+        results['names'].each do |name_info|
+            if name_info['language']['name'] == 'zh-Hant'
+                return name_info['name']
+            end
+        end
+        return "Not Found"
+    end
+
+    def pokemon_text_jp(pokemon_id)
+        url = "#{BASE_URL}#{POKEMON_SPECIES_URL}#{pokemon_id.to_s}"
+        client = HTTPClient.new                 # インスタンスを生成
+        response = client.get(url)   
+        results=JSON.parse(response.body) 
+        results['flavor_text_entries'].each do |flavor_text_entries_info|
+            if flavor_text_entries_info['language']['name']== "ja" || flavor_text_entries_info['language']['name'] == "ja-Hrkt"
+                return flavor_text_entries_info['flavor_text']
+            end
+        end
+        return "Not Found"
+    end
+
+    def pokemon_type_jp(pokemon_id)
+        url = "#{BASE_URL}#{POKEMON_URL}#{pokemon_id.to_s}"
+        types=[]
+        client = HTTPClient.new                 # インスタンスを生成
+        response = client.get(url)   
+        results=JSON.parse(response.body) 
+        results['types'].each do |type_en|
+            response_type = client.get(type_en['type']['url'])
+            results_type=JSON.parse(response_type.body)
+            results_type['names'].each do |type_name|
+                p type_name
+                if type_name['language']['name'] == "ja-Hrkt"
+                    types.push(type_name['name'])
+                end
+            end
+        end
+        return types
+    end
 end

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -32,6 +32,7 @@ class Quiz < ApplicationRecord
 
     def image_message(base_url)
         image_url = "#{base_url}#{ActionController::Base.helpers.asset_url('gray/'+format("%03d", pokemon_id))}"
+        p image_url
         image_message = {
             type: 'image',
             originalContentUrl: image_url,

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -105,7 +105,7 @@ class Quiz < ApplicationRecord
         url = "#{BASE_URL}#{POKEMON_SPECIES_URL}#{self.pokemon_id.to_s}"
         client = HTTPClient.new                 # インスタンスを生成
         response = client.get(url)   
-        results=JSON.parse(response.body) 
+        JSON.parse(response.body) 
     end
 
     def pokemon_name_jp
@@ -138,7 +138,7 @@ class Quiz < ApplicationRecord
         return "Not Found"
     end
 
-    def pokemon_text_jp(pokemon_id)
+    def pokemon_text_jp
         results=pokemon_species
         results['flavor_text_entries'].each do |flavor_text_entries_info|
             if flavor_text_entries_info['language']['name']== "ja" || flavor_text_entries_info['language']['name'] == "ja-Hrkt"
@@ -148,8 +148,8 @@ class Quiz < ApplicationRecord
         return "Not Found"
     end
 
-    def pokemon_type_jp(pokemon_id)
-        url = "#{BASE_URL}#{POKEMON_URL}#{pokemon_id.to_s}"
+    def pokemon_type_jp
+        url = "#{BASE_URL}#{POKEMON_URL}#{self.pokemon_id.to_s}"
         types=[]
         client = HTTPClient.new                 # インスタンスを生成
         response = client.get(url)   

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -136,12 +136,10 @@ class Quiz < ApplicationRecord
         results=JSON.parse(response.body) 
         results['types'].each do |type_en|
             response_type = client.get(type_en['type']['url'])
-            results_type=JSON.parse(response_type.body)
-            results_type['names'].each do |type_name|
-                p type_name
-                if type_name['language']['name'] == "ja-Hrkt"
-                    types.push(type_name['name'])
-                end
+            results_type = JSON.parse(response_type.body)
+            type_name = results_type['names'].find{|type_name| type_name['language']['name'] == "ja-Hrkt"}
+            if !type_name.nil?
+                types.push(type_name['name'])
             end
         end
         return types

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -101,11 +101,15 @@ class Quiz < ApplicationRecord
         false
     end 
 
-    def pokemon_name_jp(pokemon_id)
-        url = "#{BASE_URL}#{POKEMON_SPECIES_URL}#{pokemon_id.to_s}"
+    def pokemon_species
+        url = "#{BASE_URL}#{POKEMON_SPECIES_URL}#{self.pokemon_id.to_s}"
         client = HTTPClient.new                 # インスタンスを生成
         response = client.get(url)   
         results=JSON.parse(response.body) 
+    end
+
+    def pokemon_name_jp
+        results=pokemon_species
         results['names'].each do |name_info|
             if name_info['language']['name'] == 'ja-Hrkt'
                 return name_info['name']
@@ -114,11 +118,8 @@ class Quiz < ApplicationRecord
         return "Not Found"
     end
 
-    def pokemon_name_en(pokemon_id)
-        url = "#{BASE_URL}#{POKEMON_SPECIES_URL}#{pokemon_id.to_s}"
-        client = HTTPClient.new                 # インスタンスを生成
-        response = client.get(url)   
-        results=JSON.parse(response.body) 
+    def pokemon_name_en
+        results=pokemon_species
         results['names'].each do |name_info|
             if name_info['language']['name'] == 'en'
                 return name_info['name']
@@ -127,11 +128,8 @@ class Quiz < ApplicationRecord
         return "Not Found"
     end
 
-    def pokemon_name_ch(pokemon_id)
-        url = "#{BASE_URL}#{POKEMON_SPECIES_URL}#{pokemon_id.to_s}"
-        client = HTTPClient.new                 # インスタンスを生成
-        response = client.get(url)   
-        results=JSON.parse(response.body) 
+    def pokemon_name_ch
+        results=pokemon_species
         results['names'].each do |name_info|
             if name_info['language']['name'] == 'zh-Hant'
                 return name_info['name']
@@ -141,10 +139,7 @@ class Quiz < ApplicationRecord
     end
 
     def pokemon_text_jp(pokemon_id)
-        url = "#{BASE_URL}#{POKEMON_SPECIES_URL}#{pokemon_id.to_s}"
-        client = HTTPClient.new                 # インスタンスを生成
-        response = client.get(url)   
-        results=JSON.parse(response.body) 
+        results=pokemon_species
         results['flavor_text_entries'].each do |flavor_text_entries_info|
             if flavor_text_entries_info['language']['name']== "ja" || flavor_text_entries_info['language']['name'] == "ja-Hrkt"
                 return flavor_text_entries_info['flavor_text']

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -1,4 +1,6 @@
-require "httpclient"
+require 'httpclient'
+require 'utils/silhouette'
+
 class Quiz < ApplicationRecord
     CHALLENGE_UPPER_LIMIT = 5
     MAX_POKEMON_ID = 151
@@ -32,7 +34,6 @@ class Quiz < ApplicationRecord
 
     def image_message(base_url)
         image_url = "#{base_url}#{ActionController::Base.helpers.asset_url('gray/'+format("%03d", pokemon_id))}"
-        p image_url
         image_message = {
             type: 'image',
             originalContentUrl: image_url,
@@ -114,19 +115,13 @@ class Quiz < ApplicationRecord
     def pokemon_name(language) #'en' 'zh-Hant' 'ja-Hrkt'
         results = pokemon_species
         name_info = results['names'].find{|name_info| name_info['language']['name'] == language}
-        if name_info.nil?
-            return "Not Found"
-        end
-        return name_info['name']
+        if name_info? name_info['name'] : "Not Found"
     end
 
     def pokemon_text_jp
         results = pokemon_species
         flavor_text_entries_info = results['flavor_text_entries'].find{|flavor_text_entries_info|cflavor_text_entries_info['language']['name'] == "ja-Hrkt"}
-        if flavor_text_entries_info.nil?
-            return "Not Found"
-        end
-        return flavor_text_entries_info['flavor_text']
+        if flavor_text_entries_info?  flavor_text_entries_info['flavor_text'] : "Not Found"
     end
 
     def pokemon_type_jp

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -108,30 +108,10 @@ class Quiz < ApplicationRecord
         JSON.parse(response.body) 
     end
 
-    def pokemon_name_jp
+    def pokemon_name(language) #'en' 'zh-Hant' 'ja-Hrkt'
         results=pokemon_species
         results['names'].each do |name_info|
-            if name_info['language']['name'] == 'ja-Hrkt'
-                return name_info['name']
-            end
-        end
-        return "Not Found"
-    end
-
-    def pokemon_name_en
-        results=pokemon_species
-        results['names'].each do |name_info|
-            if name_info['language']['name'] == 'en'
-                return name_info['name']
-            end
-        end
-        return "Not Found"
-    end
-
-    def pokemon_name_ch
-        results=pokemon_species
-        results['names'].each do |name_info|
-            if name_info['language']['name'] == 'zh-Hant'
+            if name_info['language']['name'] == language
                 return name_info['name']
             end
         end

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -64,7 +64,7 @@ class Quiz < ApplicationRecord
 
     def is_answer_succeed?(input_text)
         return false if validate_text?(input_text)
-        answer_text = pokemon_name_jp(self.pokemon_id)
+        answer_text = pokemon_name('ja-Hrkt')
         if  input_text == answer_text
             true
         else
@@ -101,38 +101,38 @@ class Quiz < ApplicationRecord
         false
     end 
 
+    def http_client 
+        @http_client ||= HTTPClient.new 
+    end
+
     def pokemon_species
-        url = "#{BASE_URL}#{POKEMON_SPECIES_URL}#{self.pokemon_id.to_s}"
-        client = HTTPClient.new                 # インスタンスを生成
-        response = client.get(url)   
+        url = "#{BASE_URL}#{POKEMON_SPECIES_URL}#{self.pokemon_id.to_s}"               # インスタンスを生成
+        response = http_client.get(url)   
         JSON.parse(response.body) 
     end
 
     def pokemon_name(language) #'en' 'zh-Hant' 'ja-Hrkt'
-        results=pokemon_species
-        results['names'].each do |name_info|
-            if name_info['language']['name'] == language
-                return name_info['name']
-            end
+        results = pokemon_species
+        name_info = results['names'].find{|name_info| name_info['language']['name'] == language}
+        if name_info.nil?
+            return "Not Found"
         end
-        return "Not Found"
+        return name_info['name']
     end
 
     def pokemon_text_jp
-        results=pokemon_species
-        results['flavor_text_entries'].each do |flavor_text_entries_info|
-            if flavor_text_entries_info['language']['name']== "ja" || flavor_text_entries_info['language']['name'] == "ja-Hrkt"
-                return flavor_text_entries_info['flavor_text']
-            end
+        results = pokemon_species
+        flavor_text_entries_info = results['flavor_text_entries'].find{|flavor_text_entries_info|cflavor_text_entries_info['language']['name'] == "ja-Hrkt"}
+        if flavor_text_entries_info.nil?
+            return "Not Found"
         end
-        return "Not Found"
+        return flavor_text_entries_info['flavor_text']
     end
 
     def pokemon_type_jp
         url = "#{BASE_URL}#{POKEMON_URL}#{self.pokemon_id.to_s}"
-        types=[]
-        client = HTTPClient.new                 # インスタンスを生成
-        response = client.get(url)   
+        types=[]       
+        response = http_client.get(url)   
         results=JSON.parse(response.body) 
         results['types'].each do |type_en|
             response_type = client.get(type_en['type']['url'])

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -63,7 +63,6 @@ class Quiz < ApplicationRecord
 
     def is_answer_succeed?(input_text)
         return false if validate_text?(input_text)
-        p pokemon_type(1)
         answer_text = pokemon_name_jp(self.pokemon_id)
         if  input_text == answer_text
             true


### PR DESCRIPTION
## 実装の背景・目的

表示している画像とポケモンの名前とが一致するように、ポケモンのAPIを呼び出し確認を行えるようにする。

## やったこと

ポケモンAPIの呼び出し
取得したデータを加工するメソッドの作成
ヒント用にメソッドを用意しておく

## ヒント用に作成したメソッド
pokemon_name_en 英語でポケモンの名前を取得するメソッド
pokemon_name_ch 中国語でポケモンの名前を取得するメソッド
pokemon_text_jp　ポケモンのフレーバーテキスト（図鑑の説明文）を取得するメソッド
pokemon_type_jp　ポケモンのタイプをArrayで取得するメソッド

- この後やることリスト
- [x] Pokemon APIの処理を追加する
- [ ] ヒントを流せるようにする
- [ ] 例外処理を描く
